### PR TITLE
Fix usage of yarn at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by one per file, when all files could be read simultaneously and collected.
 If you're using yarn,
 
 ```sh
-$ yarn add https://github.com/zeyla/ureaddir.ts --save
+$ yarn add https://github.com/zeyla/ureaddir.ts
 ```
 
 If using npm,


### PR DESCRIPTION
Fixes #2

This is because Yarn does not have the option `--save` at `yarn add` command as `yarn add <package-name>` behaves like `npm install <package-name> --save`. ([docs](https://yarnpkg.com/en/docs/cli/add))